### PR TITLE
fix(css): tab styling to make it more obvious which tab is active

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,25 @@ const colors = [
   "#5fb3b3",
   foregroundColor
 ];
+const css = `
+  .tab_tab {
+    background-color: rgba(0, 0, 0, 0.3);
+  }
+
+  .tab_active {
+    background-color: transparent;
+  }
+
+  .tab_active:before {
+    border: none;
+  }
+`;
 
 exports.decorateConfig = config => Object.assign(config, {
   foregroundColor,
   backgroundColor,
   cursorColor,
   borderColor,
-  colors
+  colors,
+  css
 });


### PR DESCRIPTION
# Before

![screen shot 2016-07-27 at 4 29 22 pm](https://cloud.githubusercontent.com/assets/762949/17196158/571e8890-5417-11e6-960d-ad77f87a11cc.png)
# After

![image](https://cloud.githubusercontent.com/assets/762949/17196162/63e0f176-5417-11e6-8fd8-77308184a2e3.png)
