### PR TITLE
fix(config): assign to new object, respect existing CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,14 @@ const css = `
   }
 `;
 
-exports.decorateConfig = config => Object.assign(config, {
+exports.decorateConfig = config => Object.assign({}, config, {
   foregroundColor,
   backgroundColor,
   cursorColor,
   borderColor,
   colors,
-  css
+  css: `
+    ${config.css || ''}
+    ${css}
+  `
 });


### PR DESCRIPTION
Assigns `config` to a new object, otherwise `Object.assign` is overwriting the first passed object.
Respects existing css by concatenating this plugin's CSS values to whatever is present in `config`,
it used to overwrite it.